### PR TITLE
upgrade provider to work w/ most recent release of koop-server

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,4 +1,0 @@
-# Default config
-db:
-  postgis:
-    conn: "postgres://localhost/koop-dev"

--- a/controller/index.js
+++ b/controller/index.js
@@ -1,72 +1,79 @@
 var citybikes = require('citybikes-js'),
-    extend    = require('node.extend');
+  extend = require('node.extend'),
+  BaseController = require('koop-server/lib/BaseController.js');
 
 // inherit from base controller
-var Controller = extend( {}, BaseController );
-module.exports = Controller;
+var Controller = function(Citybikes) {
 
-// general helper for not found repos
-Controller.notFound = function(req, res){
-  res.send('Must specify a network name with /networks/<networkName> or ask for all networks with /networks', 404);
-};
+  var controller = {};
+  controller.__proto__ = BaseController();
 
-// renders an empty map with a text input 
-Controller.index = function(req, res){
-  res.render(__dirname + '/../views/index');
-};
+  // general helper for not found repos
+  controller.notFound = function(req, res) {
+    res.send('Must specify a network name with /networks/<networkName> or ask for all networks with /networks', 404);
+  };
 
-// general helper for error'd requests
-function sendError(req, res){
-  res.send('There was a problem accessing Citybik.es', 500);
-};
+  // renders an empty map with a text input
+  controller.index = function(req, res) {
+    res.render(__dirname + '/../views/index');
+  };
 
-function getNetworks(req, res, forFeatureServer) {
-  var callback = req.query.callback;
-  delete req.query.callback;
+  // general helper for error'd requests
+  function sendError(req, res) {
+    res.send('There was a problem accessing Citybik.es', 500);
+  };
 
-  Citybikes.findNetworks(req.query, function(err, networks) {
-    if (!err) {
-      if (forFeatureServer !== false) {
-        delete req.query.geometry;
-        Controller._processFeatureServer(req, res, err, networks, callback);
+  function getNetworks(req, res, forFeatureServer) {
+    var callback = req.query.callback;
+    delete req.query.callback;
+    Citybikes.findNetworks(req.query, function(err, networks) {
+      if (!err) {
+        if (forFeatureServer !== false) {
+          delete req.query.geometry;
+          Controller._processFeatureServer(req, res, err, networks, callback);
+        } else {
+          res.json(networks[0]);
+        }
       } else {
-        res.json(networks[0]);
+        sendError(req, res);
       }
-    } else {
-      sendError(req, res);
-    }
-  });
-}
-
-function getStations(req, res, forFeatureServer) {
-  var callback = req.query.callback;
-  delete req.query.callback;
-
-  Citybikes.findStations(req.params.networkName, req.query, function(err, stations) {
-    if (!err) {
-      if (forFeatureServer !== false) {
-        Controller._processFeatureServer(req, res, err, stations, callback);
-      } else {
-        res.json(stations[0]);
-      }
-    } else {
-      sendError(req, res);
-    }
-  });
-}
-
-Controller.networks = function(req, res) {
-  getNetworks(req, res, false);
-}
-
-Controller.stations = function(req, res) {
-  getStations(req, res, false);
-}
-
-Controller.featureservice = function(req, res){
-  if (req.params.networkName) {
-    getStations(req, res);
-  } else {
-    getNetworks(req, res);
+    });
   }
-};
+
+  function getStations(req, res, forFeatureServer) {
+    var callback = req.query.callback;
+    delete req.query.callback;
+
+    Citybikes.findStations(req.params.networkName, req.query, function(err, stations) {
+      if (!err) {
+        if (forFeatureServer !== false) {
+          controller.processFeatureServer(req, res, err, stations, callback);
+        } else {
+          res.json(stations[0]);
+        }
+      } else {
+        sendError(req, res);
+      }
+    });
+  }
+
+  controller.networks = function(req, res) {
+
+    getNetworks(req, res, false);
+  }
+
+  controller.stations = function(req, res) {
+    getStations(req, res, false);
+  }
+
+  controller.featureservice = function(req, res) {
+    if (req.params.networkName) {
+      getStations(req, res);
+    } else {
+      getNetworks(req, res);
+    }
+  };
+  return controller;
+}
+
+module.exports = Controller;

--- a/models/Citybikes.js
+++ b/models/Citybikes.js
@@ -1,57 +1,71 @@
-var citybikes = require('citybikes-js'),
-    _ = require('lodash');
+var citybikesJs = require('citybikes-js'),
+  BaseModel = require('koop-server/lib/BaseModel.js');
+_ = require('lodash');
 
-exports.findNetworks = function(options, callback){
-  var key  = 'Networks',
+var Citybikes = function(koop) {
+
+  var citybikes = {};
+  citybikes.__proto__ = BaseModel(koop);
+
+  citybikes.findNetworks = function(options, callback) {
+    var key = 'Networks',
       type = 'Citybikes';
-  
-  Cache.get(type, key, options, function(cacheErr, entry){
-    if (cacheErr){
-      citybikes.networks(function(err, networks) {
-        if (err) {
-          callback(err, null);
-        } else {
-          var output = [{features:_.map(networks, function(n) {
-            n.properties.stationsURL = "/citybikes/network/" + n.id + "/FeatureServer/0"
-            return n;
-          })}];
-          Cache.insert(type, key, output, 0, function(insertErr, success) {
-            if (success) {
-              callback(null, output);
-            } else {
-              callback(insertErr, null);
-            }
-          });
-        }
-      });
-    } else {
-      callback( null, entry );
-    }
-  });
+
+    koop.Cache.get(type, key, options, function(cacheErr, entry) {
+      if (cacheErr) {
+        citybikesJs.networks(function(err, networks) {
+          if (err) {
+            callback(err, null);
+          } else {
+            var output = [{
+              features: _.map(networks, function(n) {
+                n.properties.stationsURL = "/citybikes/network/" + n.id + "/FeatureServer/0"
+                return n;
+              })
+            }];
+            koop.Cache.insert(type, key, output, 0, function(insertErr, success) {
+              if (success) {
+                callback(null, output);
+              } else {
+                callback(insertErr, null);
+              }
+            });
+          }
+        });
+      } else {
+        callback(null, entry);
+      }
+    });
+  };
+
+  citybikes.findStations = function(networkName, options, callback) {
+    var key = 'Stations_' + networkName,
+      type = 'Citybikes';
+
+    koop.Cache.get(type, key, options, function(cacheErr, entry) {
+      if (cacheErr) {
+        citybikesJs.stations(networkName, function(err, stations) {
+          if (err) {
+            callback(err, null);
+          } else {
+            var output = [{
+              features: stations
+            }];
+            koop.Cache.insert(type, key, output, 0, function(insertErr, success) {
+              if (success) {
+                callback(null, output);
+              } else {
+                callback(insertErr, null);
+              }
+            });
+          }
+        });
+      } else {
+        callback(null, entry);
+      }
+    });
+  };
+  return citybikes;
 };
 
-exports.findStations = function(networkName, options, callback){
-  var key  = 'Stations_' + networkName,
-      type = 'Citybikes';
-  
-  Cache.get(type, key, options, function(cacheErr, entry){
-    if (cacheErr){
-      citybikes.stations(networkName, function(err, stations) {
-        if (err) {
-          callback(err, null);
-        } else {
-          var output = [{features:stations}];
-          Cache.insert(type, key, output, 0, function(insertErr, success) {
-            if (success) {
-              callback(null, output);
-            } else {
-              callback(insertErr, null);
-            }
-          });
-        }
-      });
-    } else {
-      callback( null, entry );
-    }
-  });
-};
+module.exports = Citybikes;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "mocha test/"
   },
   "dependencies": {
-    "koop-server": "https://github.com/Esri/koop-server/tarball/master",
+    "koop-server": "~0.1.1",
     "citybikes-js": "0.1.4",
     "config": "~0.4.35",
     "ejs": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "mocha test/"
   },
   "dependencies": {
-    "koop-server": "~0.1.1",
+    "koop-server": "~0.1.4",
     "citybikes-js": "0.1.4",
     "config": "~0.4.35",
     "ejs": "~1.0.0",

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,42 +1,13 @@
 module.exports = {
-  
-  'get /citybikes/': {
-    action: 'index'
-  },
-
-  'get /citybikes': {
-    action: 'index'
-  },
-
-  'get /citybikes/networks': {
-    action: 'networks'
-  },
-
-  'get /citybikes/networks/FeatureServer': {
-    action: 'featureservice'
-  },
-
-  'get /citybikes/networks/FeatureServer/:layer': {
-    action: 'featureservice'
-  },
-
-  'get /citybikes/networks/FeatureServer/:layer/:method': {
-    action: 'featureservice'
-  },
-
-  'get /citybikes/network/:networkName': {
-    action: 'stations'
-  },
-
-  'get /citybikes/network/:networkName/FeatureServer': {
-    action: 'featureservice'
-  },
-
-  'get /citybikes/network/:networkName/FeatureServer/:layer/:method': {
-    action: 'featureservice'
-  },
-
-  'get /citybikes/network/:networkName/FeatureServer/:layer': {
-    action: 'featureservice'
-  }
+  'get /citybikes/': 'index',
+  'get /citybikes': 'index',
+  'get /citybikes/networks/': 'networks',
+  'get /citybikes/networks': 'networks',
+  'get /citybikes/networks/FeatureServer': 'featureservice',
+  'get /citybikes/networks/FeatureServer/:layer': 'featureservice',
+  'get /citybikes/networks/FeatureServer/:layer/:method': 'featureservice',
+  'get /citybikes/network/:networkName': 'stations',
+  'get /citybikes/network/:networkName/FeatureServer': 'featureservice',
+  'get /citybikes/network/:networkName/FeatureServer/:layer/:method': 'featureservice',
+  'get /citybikes/network/:networkName/FeatureServer/:layer': 'featureservice'
 }


### PR DESCRIPTION
restructure routes
new convention for inheriting from base controller and model
get rid of provider config, since it seems to be ignored
processFeatureServer is now a public method in BaseController
utilize koop.Cache
no more globals
